### PR TITLE
認証APIの実装 Close #9

### DIFF
--- a/back/.env.example
+++ b/back/.env.example
@@ -2,9 +2,21 @@
 # postgresql+asyncpg に書き換えること
 DATABASE_URL=
 
+# 現在の session 有効期限（分）
+ACCESS_TOKEN_EXPIRE_MINUTES=10080
+
+# Cookie 認証設定
+AUTH_COOKIE_NAME=access_token
+CSRF_COOKIE_NAME=csrf_token
+# ローカル開発では false。本番では true にする
+AUTH_COOKIE_SECURE=false
+# 別ドメイン構成で cookie を送るなら none + secure=true
+AUTH_COOKIE_SAMESITE=lax
+SESSION_CLEANUP_INTERVAL_MINUTES=60
+
+# JWT は現在 session 署名には未使用だが、将来の拡張や移行のため残している
 JWT_SECRET=your-secret-key-here
 JWT_ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=10080
 
 APP_ENV=development
 APP_HOST=0.0.0.0

--- a/back/.gitignore
+++ b/back/.gitignore
@@ -9,6 +9,15 @@ venv/
 __pycache__/
 *.pyc
 *.pyo
+*.pyd
 
 # Docker ボリューム等
 postgres_data/
+
+# テスト・ツール系
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# ローカル確認用
+cookies.txt

--- a/back/README.md
+++ b/back/README.md
@@ -12,10 +12,47 @@ pip install -r requirements.txt
 cp .env.example .env
 # .env を編集して DATABASE_URL などを設定
 
+# DBにテーブルを作成
+# Supabase SQL editor などで db/init.sql を実行
+
 python run.py
 ```
 
 起動後、http://localhost:8001/docs でSwagger UIを確認できる。
+
+## 認証方式
+
+- 認証は `HttpOnly cookie + server-side session` 方式
+- cookie の値は JWT ではなくランダムな `session_id`
+- セッション本体は `sessions` テーブルに保存
+- CSRF 対策として `csrf_token` cookie も発行し、状態変更系リクエストでは `X-CSRF-Token` ヘッダー検証を行う
+- `logout` 時は cookie を削除し、DB 上の session も削除する
+- 期限切れ session は API 起動中に定期削除される
+
+フロントから認証付きで叩く場合は `fetch` / `axios` 側で cookie を送る必要がある。
+
+```ts
+fetch("http://localhost:8001/auth/me", {
+  credentials: "include",
+})
+```
+
+状態変更系リクエストでは CSRF token を header に付ける。
+
+```ts
+fetch("http://localhost:8001/auth/logout", {
+  method: "POST",
+  credentials: "include",
+  headers: {
+    "X-CSRF-Token": csrfToken,
+  },
+})
+```
+
+別オリジン構成で運用する場合は、cookie 設定と CORS 設定を合わせること。
+
+- 同一サイト寄りの構成: `AUTH_COOKIE_SAMESITE=lax`
+- 完全な別ドメイン構成: `AUTH_COOKIE_SAMESITE=none` と `AUTH_COOKIE_SECURE=true`
 
 ---
 
@@ -25,10 +62,10 @@ python run.py
 
 | メソッド | パス | 説明 |
 |---|---|---|
-| POST | `/auth/register` | 新規登録。email・password・name を受け取りJWTを返す |
-| POST | `/auth/login` | ログイン。email・password を受け取りJWTを返す |
+| POST | `/auth/register` | 新規登録。email・password・name を受け取り、session cookie を発行する |
+| POST | `/auth/login` | ログイン。email・password を受け取り、session cookie を発行する |
 | GET | `/auth/me` | ログイン中ユーザの情報を返す（name・level・xp など） |
-| POST | `/auth/logout` | ログアウト（クライアント側でトークンを破棄） |
+| POST | `/auth/logout` | ログアウト。session cookie を削除し、DB 上の session も削除する |
 
 ### ゲーム `/game`
 
@@ -64,3 +101,59 @@ python run.py
 ## テーブル構成
 
 `back/db/init.sql` を参照。
+
+- `users`
+- `sessions`
+- `bases`
+- `structures`
+- `enemy_waves`
+- `enemies`
+- `movement_logs`
+- `action_logs`
+- `battle_logs`
+
+## 動作確認
+
+cookie を保存しながら確認する。
+
+### register
+
+```bash
+curl -i -X POST http://localhost:8001/auth/register \
+  -H "Content-Type: application/json" \
+  -c cookies.txt \
+  -d '{"email":"test@example.com","password":"password123","name":"test-user"}'
+```
+
+### login
+
+```bash
+curl -i -X POST http://localhost:8001/auth/login \
+  -H "Content-Type: application/json" \
+  -c cookies.txt \
+  -d '{"email":"test@example.com","password":"password123"}'
+```
+
+### me
+
+```bash
+curl -i http://localhost:8001/auth/me \
+  -b cookies.txt
+```
+
+### logout
+
+まず cookie jar から `csrf_token` を取り出す。
+
+```bash
+csrf_token=$(awk '$6 == "csrf_token" {print $7}' cookies.txt)
+```
+
+そのうえで header を付けて logout する。
+
+```bash
+curl -i -X POST http://localhost:8001/auth/logout \
+  -b cookies.txt \
+  -c cookies.txt \
+  -H "X-CSRF-Token: ${csrf_token}"
+```

--- a/back/app/config.py
+++ b/back/app/config.py
@@ -16,6 +16,11 @@ class Settings(BaseSettings):
     jwt_secret: str = "dev-secret-change-in-production"
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24 * 7  # 1 week
+    auth_cookie_name: str = "access_token"
+    auth_cookie_secure: bool = False
+    auth_cookie_samesite: str = "lax"
+    csrf_cookie_name: str = "csrf_token"
+    session_cleanup_interval_minutes: int = 60
 
     app_env: str = "development"
     app_host: str = "0.0.0.0"

--- a/back/app/db/models.py
+++ b/back/app/db/models.py
@@ -36,6 +36,20 @@ class User(Base):
     )
 
 
+class UserSession(Base):
+    __tablename__ = "sessions"
+
+    session_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        UUID(as_uuid=False), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    csrf_token: Mapped[str] = mapped_column(Text, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 class Base_(Base):
     """本拠地。Base という名前は Python 標準と被るため Base_ とする。"""
     __tablename__ = "bases"

--- a/back/app/main.py
+++ b/back/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 from app.config import settings
 from app.db.engine import AsyncSessionLocal
+from app.routers import auth
 
 app = FastAPI(
     title="Game API",
@@ -17,7 +18,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# app.include_router(auth.router)
+app.include_router(auth.router)
 # app.include_router(game.router)
 # app.include_router(structures.router)
 # app.include_router(enemies.router)

--- a/back/app/main.py
+++ b/back/app/main.py
@@ -1,13 +1,43 @@
+import asyncio
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 from app.config import settings
 from app.db.engine import AsyncSessionLocal
 from app.routers import auth
+from app.security import delete_expired_sessions
+
+
+async def _session_cleanup_loop() -> None:
+    interval_sec = max(settings.session_cleanup_interval_minutes, 1) * 60
+    while True:
+        try:
+            async with AsyncSessionLocal() as session:
+                await delete_expired_sessions(session)
+        except Exception:
+            # Cleanup should not bring the API process down.
+            pass
+        await asyncio.sleep(interval_sec)
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    cleanup_task = asyncio.create_task(_session_cleanup_loop())
+    try:
+        yield
+    finally:
+        cleanup_task.cancel()
+        try:
+            await cleanup_task
+        except asyncio.CancelledError:
+            pass
 
 app = FastAPI(
     title="Game API",
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 app.add_middleware(

--- a/back/app/routers/auth.py
+++ b/back/app/routers/auth.py
@@ -1,4 +1,65 @@
-# POST /auth/register  新規登録
-# POST /auth/login     ログイン
-# GET  /auth/me        ログイン中ユーザの情報取得
-# POST /auth/logout    ログアウト
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.engine import get_db
+from app.db.models import User
+from app.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
+from app.security import create_access_token, get_current_user, hash_password, verify_password
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post(
+    "/register",
+    response_model=TokenResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def register(
+    payload: RegisterRequest,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    existing_user = await db.execute(select(User).where(User.email == payload.email))
+    if existing_user.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email is already registered",
+        )
+
+    user = User(
+        email=str(payload.email),
+        password_hash=hash_password(payload.password),
+        name=payload.name,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    return TokenResponse(access_token=create_access_token(user.id))
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    payload: LoginRequest,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    result = await db.execute(select(User).where(User.email == payload.email))
+    user = result.scalar_one_or_none()
+
+    if user is None or not verify_password(payload.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+
+    return TokenResponse(access_token=create_access_token(user.id))
+
+
+@router.get("/me", response_model=UserResponse)
+async def me(current_user: User = Depends(get_current_user)) -> UserResponse:
+    return UserResponse.model_validate(current_user)
+
+
+@router.post("/logout")
+async def logout() -> dict[str, str]:
+    return {"message": "Logout is handled client-side"}

--- a/back/app/routers/auth.py
+++ b/back/app/routers/auth.py
@@ -1,24 +1,39 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.db.engine import get_db
 from app.db.models import User
-from app.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
-from app.security import create_access_token, get_current_user, hash_password, verify_password
+from app.schemas.auth import AuthResponse, LoginRequest, RegisterRequest, UserResponse
+from app.security import (
+    clear_auth_cookie,
+    clear_csrf_cookie,
+    create_random_csrf_token,
+    create_random_session_id,
+    delete_session,
+    get_current_user,
+    hash_password,
+    save_session,
+    set_auth_cookie,
+    set_csrf_cookie,
+    validate_csrf,
+    verify_password,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
 @router.post(
     "/register",
-    response_model=TokenResponse,
+    response_model=AuthResponse,
     status_code=status.HTTP_201_CREATED,
 )
 async def register(
     payload: RegisterRequest,
+    response: Response,
     db: AsyncSession = Depends(get_db),
-) -> TokenResponse:
+) -> AuthResponse:
     existing_user = await db.execute(select(User).where(User.email == payload.email))
     if existing_user.scalar_one_or_none() is not None:
         raise HTTPException(
@@ -35,14 +50,23 @@ async def register(
     await db.commit()
     await db.refresh(user)
 
-    return TokenResponse(access_token=create_access_token(user.id))
+    session_id = create_random_session_id()
+    csrf_token = create_random_csrf_token()
+    await save_session(db, session_id, user.id, csrf_token)
+    set_auth_cookie(response, session_id)
+    set_csrf_cookie(response, csrf_token)
+    return AuthResponse(
+        message="Registered successfully",
+        user=UserResponse.model_validate(user),
+    )
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login", response_model=AuthResponse)
 async def login(
     payload: LoginRequest,
+    response: Response,
     db: AsyncSession = Depends(get_db),
-) -> TokenResponse:
+) -> AuthResponse:
     result = await db.execute(select(User).where(User.email == payload.email))
     user = result.scalar_one_or_none()
 
@@ -52,7 +76,15 @@ async def login(
             detail="Invalid email or password",
         )
 
-    return TokenResponse(access_token=create_access_token(user.id))
+    session_id = create_random_session_id()
+    csrf_token = create_random_csrf_token()
+    await save_session(db, session_id, user.id, csrf_token)
+    set_auth_cookie(response, session_id)
+    set_csrf_cookie(response, csrf_token)
+    return AuthResponse(
+        message="Logged in successfully",
+        user=UserResponse.model_validate(user),
+    )
 
 
 @router.get("/me", response_model=UserResponse)
@@ -61,5 +93,15 @@ async def me(current_user: User = Depends(get_current_user)) -> UserResponse:
 
 
 @router.post("/logout")
-async def logout() -> dict[str, str]:
-    return {"message": "Logout is handled client-side"}
+async def logout(
+    request: Request,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+    _: None = Depends(validate_csrf),
+) -> dict[str, str]:
+    session_id = request.cookies.get(settings.auth_cookie_name)
+    if session_id:
+        await delete_session(db, session_id)
+    clear_auth_cookie(response)
+    clear_csrf_cookie(response)
+    return {"message": "Logged out successfully"}

--- a/back/app/schemas/auth.py
+++ b/back/app/schemas/auth.py
@@ -1,4 +1,28 @@
-# RegisterRequest  email, password, name
-# LoginRequest     email, password
-# TokenResponse    access_token, token_type
-# UserResponse     id, email, name, level, xp
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+    name: str | None = Field(default=None, max_length=100)
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    email: EmailStr
+    name: str | None = None
+    level: int
+    xp: int
+    energy: int

--- a/back/app/schemas/auth.py
+++ b/back/app/schemas/auth.py
@@ -12,9 +12,9 @@ class LoginRequest(BaseModel):
     password: str = Field(min_length=8, max_length=128)
 
 
-class TokenResponse(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
+class AuthResponse(BaseModel):
+    message: str
+    user: "UserResponse"
 
 
 class UserResponse(BaseModel):

--- a/back/app/security.py
+++ b/back/app/security.py
@@ -1,18 +1,16 @@
+import secrets
 from datetime import UTC, datetime, timedelta
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+from fastapi import Depends, HTTPException, Request, Response, status
 from passlib.context import CryptContext
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.db.engine import get_db
-from app.db.models import User
+from app.db.models import User, UserSession
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -23,49 +21,157 @@ def hash_password(password: str) -> str:
     return pwd_context.hash(password)
 
 
-def create_access_token(subject: str) -> str:
-    expire_at = datetime.now(UTC) + timedelta(
+def create_random_session_id() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def create_random_csrf_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def create_session_expiry() -> datetime:
+    return datetime.now(UTC) + timedelta(
         minutes=settings.access_token_expire_minutes
     )
-    payload = {
-        "sub": subject,
-        "exp": expire_at,
-    }
-    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+def set_auth_cookie(response: Response, session_id: str) -> None:
+    max_age = settings.access_token_expire_minutes * 60
+    response.set_cookie(
+        key=settings.auth_cookie_name,
+        value=session_id,
+        max_age=max_age,
+        expires=max_age,
+        httponly=True,
+        secure=settings.auth_cookie_secure,
+        samesite=settings.auth_cookie_samesite,
+        path="/",
+    )
+
+
+def set_csrf_cookie(response: Response, csrf_token: str) -> None:
+    max_age = settings.access_token_expire_minutes * 60
+    response.set_cookie(
+        key=settings.csrf_cookie_name,
+        value=csrf_token,
+        max_age=max_age,
+        expires=max_age,
+        httponly=False,
+        secure=settings.auth_cookie_secure,
+        samesite=settings.auth_cookie_samesite,
+        path="/",
+    )
+
+
+async def save_session(
+    db: AsyncSession,
+    session_id: str,
+    user_id: str,
+    csrf_token: str,
+) -> UserSession:
+    session = UserSession(
+        session_id=session_id,
+        user_id=user_id,
+        csrf_token=csrf_token,
+        expires_at=create_session_expiry(),
+    )
+    db.add(session)
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+def clear_auth_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=settings.auth_cookie_name,
+        httponly=True,
+        secure=settings.auth_cookie_secure,
+        samesite=settings.auth_cookie_samesite,
+        path="/",
+    )
+
+
+def clear_csrf_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=settings.csrf_cookie_name,
+        secure=settings.auth_cookie_secure,
+        samesite=settings.auth_cookie_samesite,
+        path="/",
+    )
+
+
+async def delete_session(db: AsyncSession, session_id: str) -> None:
+    await db.execute(delete(UserSession).where(UserSession.session_id == session_id))
+    await db.commit()
+
+
+async def delete_expired_sessions(db: AsyncSession) -> int:
+    result = await db.execute(
+        delete(UserSession)
+        .where(UserSession.expires_at <= datetime.now(UTC))
+        .returning(UserSession.session_id)
+    )
+    await db.commit()
+    return len(result.fetchall())
+
+
+async def get_current_session(
+    request: Request,
     db: AsyncSession = Depends(get_db),
-) -> User:
-    if credentials is None:
+) -> UserSession:
+    session_id = request.cookies.get(settings.auth_cookie_name)
+    if not session_id:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required",
         )
 
-    token = credentials.credentials
+    result = await db.execute(
+        select(UserSession).where(UserSession.session_id == session_id)
+    )
+    session = result.scalar_one_or_none()
 
-    try:
-        payload = jwt.decode(
-            token,
-            settings.jwt_secret,
-            algorithms=[settings.jwt_algorithm],
-        )
-    except JWTError as exc:
+    if session is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid access token",
-        ) from exc
-
-    user_id = payload.get("sub")
-    if not user_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid access token",
+            detail="Invalid session",
         )
 
-    result = await db.execute(select(User).where(User.id == user_id))
+    if session.expires_at <= datetime.now(UTC):
+        await delete_session(db, session.session_id)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired",
+        )
+
+    return session
+
+
+async def validate_csrf(
+    request: Request,
+    current_session: UserSession = Depends(get_current_session),
+) -> None:
+    csrf_cookie = request.cookies.get(settings.csrf_cookie_name)
+    csrf_header = request.headers.get("X-CSRF-Token")
+
+    if not csrf_cookie or not csrf_header:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token is required",
+        )
+
+    if csrf_cookie != current_session.csrf_token or csrf_header != current_session.csrf_token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid CSRF token",
+        )
+
+
+async def get_current_user(
+    current_session: UserSession = Depends(get_current_session),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    result = await db.execute(select(User).where(User.id == current_session.user_id))
     user = result.scalar_one_or_none()
 
     if user is None:

--- a/back/app/security.py
+++ b/back/app/security.py
@@ -1,0 +1,77 @@
+from datetime import UTC, datetime, timedelta
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.db.engine import get_db
+from app.db.models import User
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str) -> str:
+    expire_at = datetime.now(UTC) + timedelta(
+        minutes=settings.access_token_expire_minutes
+    )
+    payload = {
+        "sub": subject,
+        "exp": expire_at,
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    token = credentials.credentials
+
+    try:
+        payload = jwt.decode(
+            token,
+            settings.jwt_secret,
+            algorithms=[settings.jwt_algorithm],
+        )
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid access token",
+        ) from exc
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid access token",
+        )
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+
+    return user

--- a/back/db/init.sql
+++ b/back/db/init.sql
@@ -15,6 +15,25 @@ CREATE TABLE IF NOT EXISTS users (
     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- セッション
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id  TEXT PRIMARY KEY,
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    csrf_token  TEXT NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS csrf_token TEXT;
+
+UPDATE sessions
+SET csrf_token = md5(random()::text || clock_timestamp()::text)
+WHERE csrf_token IS NULL;
+
+ALTER TABLE sessions
+    ALTER COLUMN csrf_token SET NOT NULL;
+
 -- 拠点
 CREATE TABLE IF NOT EXISTS bases (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -9,3 +9,5 @@ python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 bcrypt==4.0.1
 python-multipart>=0.0.9
+httpx>=0.27.0
+pytest>=8.0.0

--- a/back/tests/conftest.py
+++ b/back/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+
+BACK_DIR = Path(__file__).resolve().parents[1]
+
+if str(BACK_DIR) not in sys.path:
+    sys.path.insert(0, str(BACK_DIR))

--- a/back/tests/test_auth.py
+++ b/back/tests/test_auth.py
@@ -1,0 +1,249 @@
+import asyncio
+import uuid
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.db.engine import get_db
+from app.db.models import User, UserSession
+from app.main import app
+from app.security import delete_expired_sessions
+
+
+class FakeResult:
+    def __init__(self, scalar=None, rows=None):
+        self._scalar = scalar
+        self._rows = rows or []
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class FakeAsyncSession:
+    def __init__(self):
+        self.users_by_id: dict[str, User] = {}
+        self.users_by_email: dict[str, User] = {}
+        self.sessions_by_id: dict[str, UserSession] = {}
+
+    def add(self, obj):
+        now = datetime.now(UTC)
+
+        if isinstance(obj, User):
+            if not obj.id:
+                obj.id = str(uuid.uuid4())
+            if obj.level is None:
+                obj.level = 1
+            if obj.xp is None:
+                obj.xp = 0
+            if obj.energy is None:
+                obj.energy = 100
+            if obj.created_at is None:
+                obj.created_at = now
+            self.users_by_id[obj.id] = obj
+            self.users_by_email[obj.email] = obj
+            return
+
+        if isinstance(obj, UserSession):
+            if obj.created_at is None:
+                obj.created_at = now
+            self.sessions_by_id[obj.session_id] = obj
+            return
+
+        raise TypeError(f"Unsupported object type: {type(obj)!r}")
+
+    async def commit(self):
+        return None
+
+    async def refresh(self, _obj):
+        return None
+
+    async def execute(self, statement):
+        if statement.__class__.__name__ == "Select":
+            entity = statement.column_descriptions[0]["entity"]
+            where = statement.whereclause
+            if entity is User:
+                key = where.left.key
+                value = where.right.value
+                if key == "email":
+                    return FakeResult(scalar=self.users_by_email.get(value))
+                if key == "id":
+                    return FakeResult(scalar=self.users_by_id.get(value))
+
+            if entity is UserSession:
+                key = where.left.key
+                value = where.right.value
+                if key == "session_id":
+                    return FakeResult(scalar=self.sessions_by_id.get(value))
+
+        if statement.__class__.__name__ == "Delete" and statement.table.name == "sessions":
+            where = statement.whereclause
+            key = where.left.key
+            deleted_ids: list[tuple[str]] = []
+
+            if key == "session_id":
+                value = where.right.value
+                if value in self.sessions_by_id:
+                    del self.sessions_by_id[value]
+                    deleted_ids.append((value,))
+
+            if key == "expires_at":
+                deadline = where.right.value
+                expired_ids = [
+                    session_id
+                    for session_id, session in self.sessions_by_id.items()
+                    if session.expires_at <= deadline
+                ]
+                for session_id in expired_ids:
+                    del self.sessions_by_id[session_id]
+                    deleted_ids.append((session_id,))
+
+            return FakeResult(rows=deleted_ids)
+
+        raise AssertionError(f"Unsupported statement: {statement!r}")
+
+
+@contextmanager
+def auth_client():
+    db = FakeAsyncSession()
+
+    async def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(app) as client:
+            yield client, db
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_register_sets_session_and_csrf_cookies():
+    with auth_client() as (client, db):
+        response = client.post(
+            "/auth/register",
+            json={
+                "email": "test@example.com",
+                "password": "password123",
+                "name": "tester",
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["message"] == "Registered successfully"
+        assert response.cookies.get("access_token")
+        assert response.cookies.get("csrf_token")
+        assert len(db.sessions_by_id) == 1
+
+
+def test_me_works_with_session_cookie():
+    with auth_client() as (client, _db):
+        client.post(
+            "/auth/register",
+            json={
+                "email": "test@example.com",
+                "password": "password123",
+                "name": "tester",
+            },
+        )
+
+        response = client.get("/auth/me")
+
+        assert response.status_code == 200
+        assert response.json()["email"] == "test@example.com"
+
+
+def test_login_rejects_invalid_password():
+    with auth_client() as (client, _db):
+        client.post(
+            "/auth/register",
+            json={
+                "email": "test@example.com",
+                "password": "password123",
+                "name": "tester",
+            },
+        )
+        client.cookies.clear()
+
+        response = client.post(
+            "/auth/login",
+            json={
+                "email": "test@example.com",
+                "password": "wrongpass123",
+            },
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid email or password"
+
+
+def test_logout_requires_csrf_header():
+    with auth_client() as (client, _db):
+        client.post(
+            "/auth/register",
+            json={
+                "email": "test@example.com",
+                "password": "password123",
+                "name": "tester",
+            },
+        )
+
+        response = client.post("/auth/logout")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "CSRF token is required"
+
+
+def test_logout_deletes_session_and_cookies():
+    with auth_client() as (client, db):
+        client.post(
+            "/auth/register",
+            json={
+                "email": "test@example.com",
+                "password": "password123",
+                "name": "tester",
+            },
+        )
+        csrf_token = client.cookies.get("csrf_token")
+        session_id = client.cookies.get("access_token")
+
+        response = client.post(
+            "/auth/logout",
+            headers={"X-CSRF-Token": csrf_token},
+        )
+
+        assert response.status_code == 200
+        assert session_id not in db.sessions_by_id
+        assert client.get("/auth/me").status_code == 401
+
+
+def test_delete_expired_sessions_removes_only_expired_rows():
+    db = FakeAsyncSession()
+    now = datetime.now(UTC)
+
+    active_session = UserSession(
+        session_id="active",
+        user_id=str(uuid.uuid4()),
+        csrf_token="csrf-active",
+        expires_at=now + timedelta(minutes=10),
+    )
+    expired_session = UserSession(
+        session_id="expired",
+        user_id=str(uuid.uuid4()),
+        csrf_token="csrf-expired",
+        expires_at=now - timedelta(minutes=10),
+    )
+    db.add(active_session)
+    db.add(expired_session)
+
+    deleted_count = asyncio.run(delete_expired_sessions(db))
+
+    assert deleted_count == 1
+    assert "expired" not in db.sessions_by_id
+    assert "active" in db.sessions_by_id


### PR DESCRIPTION
## Summary
Issue #9 対応。

バックエンドの認証機能を実装しました。
新規登録、ログイン、ログイン中ユーザー取得、ログアウトの API を追加し、認証方式は `HttpOnly cookie + server-side session` ベースにしています。

## Changes
- `/auth/register` を実装
- `/auth/login` を実装
- `/auth/me` を実装
- `/auth/logout` を実装
- `sessions` テーブルと `UserSession` モデルを追加
- session cookie による認証フローを実装
- CSRF 対策として `csrf_token` cookie と `X-CSRF-Token` 検証を追加
- 期限切れ session を定期削除する cleanup loop を追加
- `README.md`, `.env.example`, `.gitignore` を更新
- auth の自動テストを追加

## Validation
- `pytest -q`
- 結果: `6 passed`

## Notes
- DB には `back/db/init.sql` の反映が必要
- ローカルでは `AUTH_COOKIE_SECURE=false`
- 本番では `AUTH_COOKIE_SECURE=true` を想定
