### PR TITLE
close #10 implement Feat/backend game base start

### DIFF
--- a/back/.env.test.example
+++ b/back/.env.test.example
@@ -1,0 +1,1 @@
+TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5433/camp_test

--- a/back/README.md
+++ b/back/README.md
@@ -157,3 +157,23 @@ curl -i -X POST http://localhost:8001/auth/logout \
   -c cookies.txt \
   -H "X-CSRF-Token: ${csrf_token}"
 ```
+
+## Integration Test
+
+ローカル PostgreSQL を Docker で立てて、実DB integration test を回せる。
+
+```bash
+docker run --name camp-postgres-test \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_DB=camp_test \
+  -p 5433:5432 \
+  -d postgres:16
+```
+
+`TEST_DATABASE_URL` を設定する。`.env.test.example` を参考にする。
+
+```bash
+export TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5433/camp_test
+pytest -q tests/integration -m integration
+```

--- a/back/app/main.py
+++ b/back/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 from app.config import settings
 from app.db.engine import AsyncSessionLocal
-from app.routers import auth
+from app.routers import auth, game
 from app.security import delete_expired_sessions
 
 
@@ -49,7 +49,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router)
-# app.include_router(game.router)
+app.include_router(game.router)
 # app.include_router(structures.router)
 # app.include_router(enemies.router)
 

--- a/back/app/routers/game.py
+++ b/back/app/routers/game.py
@@ -1,4 +1,152 @@
-# POST /game/base    拠点を設定（緯度経度を登録）
-# POST /game/start   ゲーム開始（難易度を受け取ってウェーブ・敵を生成）
-# POST /game/clear   クリア（報酬付与）
-# POST /game/end     強制終了（報酬なし）
+import random
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
+
+from app.db.engine import get_db
+from app.db.models import Base_ as UserBase
+from app.db.models import Enemy, EnemyWave, User
+from app.schemas.game import (
+    BaseResponse,
+    BaseSetupRequest,
+    GameStateResponse,
+    StageSelectRequest,
+)
+from app.security import get_current_user, validate_csrf
+
+router = APIRouter(prefix="/game", tags=["game"])
+
+
+def _generate_enemy_specs(base: UserBase, difficulty: int, seed: int) -> list[dict]:
+    rng = random.Random(seed)
+    enemy_count = difficulty * 3
+    enemies = []
+    for index in range(enemy_count):
+        lat_offset = rng.uniform(-0.003, 0.003)
+        lng_offset = rng.uniform(-0.003, 0.003)
+        enemies.append(
+            {
+                "enemy_type": "virus",
+                "name": f"Virus {index + 1}",
+                "hp": 20 + difficulty * 10,
+                "max_hp": 20 + difficulty * 10,
+                "attack": 4 + difficulty,
+                "speed": 0.8 + (difficulty * 0.1),
+                "state": "spawned",
+                "lat": base.lat + lat_offset,
+                "lng": base.lng + lng_offset,
+            }
+        )
+    return enemies
+
+
+@router.post("/base", response_model=BaseResponse)
+async def setup_base(
+    payload: BaseSetupRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(validate_csrf),
+) -> BaseResponse:
+    result = await db.execute(select(UserBase).where(UserBase.user_id == current_user.id))
+    base = result.scalar_one_or_none()
+
+    if base is None:
+        base = UserBase(
+            user_id=current_user.id,
+            name=payload.name or "Home Base",
+            lat=payload.lat,
+            lng=payload.lng,
+        )
+        db.add(base)
+    else:
+        base.name = payload.name or base.name
+        base.lat = payload.lat
+        base.lng = payload.lng
+
+    current_user.home_lat = payload.lat
+    current_user.home_lng = payload.lng
+
+    await db.commit()
+    await db.refresh(base)
+    return BaseResponse.model_validate(base)
+
+
+@router.post(
+    "/start",
+    response_model=GameStateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def start_game(
+    payload: StageSelectRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(validate_csrf),
+) -> GameStateResponse:
+    base_result = await db.execute(select(UserBase).where(UserBase.user_id == current_user.id))
+    base = base_result.scalar_one_or_none()
+    if base is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Base is not set",
+        )
+
+    waves_result = await db.execute(
+        select(EnemyWave).where(EnemyWave.user_id == current_user.id)
+    )
+    existing_wave = next(
+        (
+            wave
+            for wave in waves_result.scalars().all()
+            if wave.status in {"pending", "active"}
+        ),
+        None,
+    )
+    if existing_wave is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An active wave already exists",
+        )
+
+    seed = random.randint(1, 10**9)
+    started_at = datetime.now(UTC)
+    enemy_specs = _generate_enemy_specs(base, payload.difficulty, seed)
+
+    wave = EnemyWave(
+        user_id=current_user.id,
+        wave_type="session",
+        difficulty=payload.difficulty,
+        started_at=started_at,
+        status="active",
+        seed=seed,
+    )
+
+    try:
+        async with db.begin():
+            db.add(wave)
+            await db.flush()
+
+            for spec in enemy_specs:
+                enemy = Enemy(
+                    user_id=current_user.id,
+                    wave_id=wave.id,
+                    target_base_id=base.id,
+                    **spec,
+                )
+                db.add(enemy)
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An active wave already exists",
+        ) from exc
+
+    return GameStateResponse(
+        wave_id=wave.id,
+        status=wave.status,
+        difficulty=wave.difficulty,
+        started_at=wave.started_at,
+        enemy_count=len(enemy_specs),
+    )

--- a/back/app/routers/game.py
+++ b/back/app/routers/game.py
@@ -124,18 +124,19 @@ async def start_game(
     )
 
     try:
-        async with db.begin():
-            db.add(wave)
-            await db.flush()
+        db.add(wave)
+        await db.flush()
 
-            for spec in enemy_specs:
-                enemy = Enemy(
-                    user_id=current_user.id,
-                    wave_id=wave.id,
-                    target_base_id=base.id,
-                    **spec,
-                )
-                db.add(enemy)
+        for spec in enemy_specs:
+            enemy = Enemy(
+                user_id=current_user.id,
+                wave_id=wave.id,
+                target_base_id=base.id,
+                **spec,
+            )
+            db.add(enemy)
+
+        await db.commit()
     except IntegrityError as exc:
         await db.rollback()
         raise HTTPException(

--- a/back/app/schemas/game.py
+++ b/back/app/schemas/game.py
@@ -1,3 +1,33 @@
-# BaseSetupRequest   lat, lng, name
-# StageSelectRequest difficulty（1〜5）
-# GameStateResponse  wave_id, status, difficulty, started_at
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BaseSetupRequest(BaseModel):
+    lat: float = Field(ge=-90, le=90)
+    lng: float = Field(ge=-180, le=180)
+    name: str | None = Field(default=None, max_length=100)
+
+
+class BaseResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    lat: float
+    lng: float
+    hp: int
+    max_hp: int
+    shield: int
+
+
+class StageSelectRequest(BaseModel):
+    difficulty: int = Field(ge=1, le=5)
+
+
+class GameStateResponse(BaseModel):
+    wave_id: str
+    status: str
+    difficulty: int
+    started_at: datetime
+    enemy_count: int

--- a/back/db/init.sql
+++ b/back/db/init.sql
@@ -81,6 +81,10 @@ CREATE TABLE IF NOT EXISTS enemy_waves (
     seed            INTEGER NOT NULL DEFAULT 0
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS uq_active_wave_per_user
+ON enemy_waves (user_id)
+WHERE status IN ('pending', 'active');
+
 -- 敵
 CREATE TABLE IF NOT EXISTS enemies (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/back/pytest.ini
+++ b/back/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+markers =
+    integration: tests that require a real PostgreSQL database

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -11,3 +11,4 @@ bcrypt==4.0.1
 python-multipart>=0.0.9
 httpx>=0.27.0
 pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/back/tests/fakes.py
+++ b/back/tests/fakes.py
@@ -1,0 +1,222 @@
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.db.engine import get_db
+from app.db.models import Base_ as UserBase
+from app.db.models import Enemy, EnemyWave, User, UserSession
+from app.routers import auth, game
+
+
+class FakeScalarResult:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def all(self):
+        return list(self._items)
+
+
+class FakeResult:
+    def __init__(self, items=None, rows=None):
+        self._items = list(items or [])
+        self._rows = rows or []
+
+    def scalar_one_or_none(self):
+        if not self._items:
+            return None
+        return self._items[0]
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+    def scalars(self):
+        return FakeScalarResult(self._items)
+
+
+class FakeAsyncSession:
+    def __init__(self):
+        self.users_by_id: dict[str, User] = {}
+        self.users_by_email: dict[str, User] = {}
+        self.sessions_by_id: dict[str, UserSession] = {}
+        self.bases_by_id: dict[str, UserBase] = {}
+        self.bases_by_user_id: dict[str, UserBase] = {}
+        self.waves_by_id: dict[str, EnemyWave] = {}
+        self.enemies_by_id: dict[str, Enemy] = {}
+
+    def add(self, obj):
+        now = datetime.now(UTC)
+
+        if isinstance(obj, User):
+            if not obj.id:
+                obj.id = str(uuid.uuid4())
+            if obj.level is None:
+                obj.level = 1
+            if obj.xp is None:
+                obj.xp = 0
+            if obj.energy is None:
+                obj.energy = 100
+            if obj.created_at is None:
+                obj.created_at = now
+            self.users_by_id[obj.id] = obj
+            self.users_by_email[obj.email] = obj
+            return
+
+        if isinstance(obj, UserSession):
+            if obj.created_at is None:
+                obj.created_at = now
+            self.sessions_by_id[obj.session_id] = obj
+            return
+
+        if isinstance(obj, UserBase):
+            if not obj.id:
+                obj.id = str(uuid.uuid4())
+            if obj.hp is None:
+                obj.hp = 1000
+            if obj.max_hp is None:
+                obj.max_hp = 1000
+            if obj.shield is None:
+                obj.shield = 0
+            if obj.created_at is None:
+                obj.created_at = now
+            self.bases_by_id[obj.id] = obj
+            self.bases_by_user_id[obj.user_id] = obj
+            return
+
+        if isinstance(obj, EnemyWave):
+            if not obj.id:
+                obj.id = str(uuid.uuid4())
+            if obj.wave_type is None:
+                obj.wave_type = "session"
+            if obj.status is None:
+                obj.status = "active"
+            if obj.seed is None:
+                obj.seed = 0
+            if obj.started_at is None:
+                obj.started_at = now
+            self.waves_by_id[obj.id] = obj
+            return
+
+        if isinstance(obj, Enemy):
+            if not obj.id:
+                obj.id = str(uuid.uuid4())
+            if obj.attack is None:
+                obj.attack = 5
+            if obj.speed is None:
+                obj.speed = 1.0
+            if obj.state is None:
+                obj.state = "spawned"
+            if obj.spawned_at is None:
+                obj.spawned_at = now
+            self.enemies_by_id[obj.id] = obj
+            return
+
+        raise TypeError(f"Unsupported object type: {type(obj)!r}")
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+    async def flush(self):
+        return None
+
+    async def refresh(self, _obj):
+        return None
+
+    def begin(self):
+        return _FakeTransaction()
+
+    async def execute(self, statement):
+        statement_type = statement.__class__.__name__
+
+        if statement_type == "Select":
+            entity = statement.column_descriptions[0]["entity"]
+            items = list(self._iter_entity(entity))
+            where = statement.whereclause
+            if where is not None:
+                items = [item for item in items if self._matches(where, item)]
+            return FakeResult(items=items)
+
+        if statement_type == "Delete" and statement.table.name == "sessions":
+            deleted_ids = []
+            to_delete = [
+                session_id
+                for session_id, session in self.sessions_by_id.items()
+                if self._matches(statement.whereclause, session)
+            ]
+            for session_id in to_delete:
+                del self.sessions_by_id[session_id]
+                deleted_ids.append((session_id,))
+            return FakeResult(rows=deleted_ids)
+
+        raise AssertionError(f"Unsupported statement: {statement!r}")
+
+    def _iter_entity(self, entity):
+        if entity is User:
+            return self.users_by_id.values()
+        if entity is UserSession:
+            return self.sessions_by_id.values()
+        if entity is UserBase:
+            return self.bases_by_id.values()
+        if entity is EnemyWave:
+            return self.waves_by_id.values()
+        if entity is Enemy:
+            return self.enemies_by_id.values()
+        raise AssertionError(f"Unsupported entity: {entity!r}")
+
+    def _matches(self, clause, obj):
+        clause_type = clause.__class__.__name__
+        if clause_type == "BooleanClauseList":
+            return all(self._matches(item, obj) for item in clause.clauses)
+
+        if clause_type == "BinaryExpression":
+            key = clause.left.key
+            current = getattr(obj, key)
+            value = getattr(clause.right, "value", None)
+            operator_name = clause.operator.__name__
+
+            if operator_name == "eq":
+                return current == value
+            if operator_name == "le":
+                return current <= value
+            if operator_name == "in_op":
+                return current in value
+
+        raise AssertionError(f"Unsupported clause: {clause!r}")
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@asynccontextmanager
+async def app_client():
+    db = FakeAsyncSession()
+    test_app = FastAPI()
+    test_app.include_router(auth.router)
+    test_app.include_router(game.router)
+
+    async def override_get_db():
+        yield db
+
+    test_app.dependency_overrides[get_db] = override_get_db
+    try:
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            yield client, db
+    finally:
+        test_app.dependency_overrides.clear()

--- a/back/tests/integration/conftest.py
+++ b/back/tests/integration/conftest.py
@@ -1,0 +1,106 @@
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.db.engine import get_db
+from app.routers import auth, game
+
+TEST_DATABASE_URL = os.getenv(
+    "TEST_DATABASE_URL",
+    "postgresql+asyncpg://postgres:postgres@localhost:5433/camp_test",
+)
+
+TABLES = [
+    "battle_logs",
+    "action_logs",
+    "movement_logs",
+    "enemies",
+    "enemy_waves",
+    "structures",
+    "bases",
+    "sessions",
+    "users",
+]
+
+
+def _read_sql_statements() -> list[str]:
+    sql_text = Path("db/init.sql").read_text()
+    return [statement.strip() for statement in sql_text.split(";") if statement.strip()]
+
+
+async def _apply_schema(engine) -> None:
+    async with engine.begin() as conn:
+        for statement in _read_sql_statements():
+            await conn.execute(text(statement))
+
+
+async def _truncate_tables(session: AsyncSession) -> None:
+    joined_tables = ", ".join(TABLES)
+    await session.execute(text(f"TRUNCATE TABLE {joined_tables} RESTART IDENTITY CASCADE"))
+    await session.commit()
+
+
+@pytest.fixture(scope="session")
+def integration_db_url():
+    return TEST_DATABASE_URL
+
+
+@pytest_asyncio.fixture(scope="function")
+async def integration_engine(integration_db_url):
+    engine = create_async_engine(
+        integration_db_url,
+        future=True,
+        poolclass=NullPool,
+    )
+    await _apply_schema(engine)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture(scope="function")
+async def db_sessionmaker(integration_engine):
+    return async_sessionmaker(integration_engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_database(db_sessionmaker):
+    async with db_sessionmaker() as session:
+        await _truncate_tables(session)
+    yield
+
+
+@pytest_asyncio.fixture
+async def integration_client(db_sessionmaker):
+    test_app = FastAPI()
+    test_app.include_router(auth.router)
+    test_app.include_router(game.router)
+
+    async def override_get_db():
+        async with db_sessionmaker() as session:
+            yield session
+
+    test_app.dependency_overrides[get_db] = override_get_db
+
+    @asynccontextmanager
+    async def _client():
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            yield client
+
+    try:
+        yield _client
+    finally:
+        test_app.dependency_overrides.clear()

--- a/back/tests/integration/test_game_integration.py
+++ b/back/tests/integration/test_game_integration.py
@@ -1,0 +1,129 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import Base_ as UserBase
+from app.db.models import Enemy, EnemyWave, User
+
+
+async def _register(client, email="integration@example.com"):
+    response = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": "password123",
+            "name": "integration-user",
+        },
+    )
+    assert response.status_code == 201
+    return {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+
+@pytest.mark.integration
+async def test_base_setup_persists_base(integration_client, db_sessionmaker):
+    async with integration_client() as client:
+        headers = await _register(client)
+        response = await client.post(
+            "/game/base",
+            json={"lat": 35.681236, "lng": 139.767125, "name": "Tokyo Base"},
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+
+    async with db_sessionmaker() as session:
+        bases = (await session.execute(select(UserBase))).scalars().all()
+        assert len(bases) == 1
+        assert bases[0].name == "Tokyo Base"
+
+
+@pytest.mark.integration
+async def test_start_requires_base(integration_client):
+    async with integration_client() as client:
+        headers = await _register(client)
+        response = await client.post(
+            "/game/start",
+            json={"difficulty": 3},
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Base is not set"
+
+
+@pytest.mark.integration
+async def test_start_persists_wave_and_enemies(integration_client, db_sessionmaker):
+    async with integration_client() as client:
+        headers = await _register(client)
+        await client.post(
+            "/game/base",
+            json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+            headers=headers,
+        )
+        response = await client.post(
+            "/game/start",
+            json={"difficulty": 2},
+            headers=headers,
+        )
+
+        assert response.status_code == 201
+        assert response.json()["enemy_count"] == 6
+        assert "seed" not in response.json()
+
+    async with db_sessionmaker() as session:
+        waves = (await session.execute(select(EnemyWave))).scalars().all()
+        enemies = (await session.execute(select(Enemy))).scalars().all()
+        assert len(waves) == 1
+        assert len(enemies) == 6
+
+
+@pytest.mark.integration
+async def test_start_rejects_second_active_wave(integration_client):
+    async with integration_client() as client:
+        headers = await _register(client)
+        await client.post(
+            "/game/base",
+            json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+            headers=headers,
+        )
+        first = await client.post("/game/start", json={"difficulty": 2}, headers=headers)
+        second = await client.post("/game/start", json={"difficulty": 4}, headers=headers)
+
+        assert first.status_code == 201
+        assert second.status_code == 409
+        assert second.json()["detail"] == "An active wave already exists"
+
+
+@pytest.mark.integration
+async def test_db_constraint_blocks_two_active_waves_for_one_user(db_sessionmaker):
+    async with db_sessionmaker() as session:
+        user = User(email="db@example.com", password_hash="hashed", name="db-user")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+
+        first_wave = EnemyWave(
+            user_id=user.id,
+            wave_type="session",
+            difficulty=1,
+            status="active",
+            seed=123,
+        )
+        second_wave = EnemyWave(
+            user_id=user.id,
+            wave_type="session",
+            difficulty=2,
+            status="active",
+            seed=456,
+        )
+        session.add(first_wave)
+        await session.commit()
+
+        session.add(second_wave)
+        try:
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            return
+
+        raise AssertionError("Expected IntegrityError for duplicate active wave")

--- a/back/tests/test_auth.py
+++ b/back/tests/test_auth.py
@@ -1,226 +1,124 @@
 import asyncio
 import uuid
-from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
-from fastapi.testclient import TestClient
-
-from app.db.engine import get_db
-from app.db.models import User, UserSession
-from app.main import app
+from app.db.models import UserSession
 from app.security import delete_expired_sessions
-
-
-class FakeResult:
-    def __init__(self, scalar=None, rows=None):
-        self._scalar = scalar
-        self._rows = rows or []
-
-    def scalar_one_or_none(self):
-        return self._scalar
-
-    def first(self):
-        return self._rows[0] if self._rows else None
-
-    def fetchall(self):
-        return self._rows
-
-
-class FakeAsyncSession:
-    def __init__(self):
-        self.users_by_id: dict[str, User] = {}
-        self.users_by_email: dict[str, User] = {}
-        self.sessions_by_id: dict[str, UserSession] = {}
-
-    def add(self, obj):
-        now = datetime.now(UTC)
-
-        if isinstance(obj, User):
-            if not obj.id:
-                obj.id = str(uuid.uuid4())
-            if obj.level is None:
-                obj.level = 1
-            if obj.xp is None:
-                obj.xp = 0
-            if obj.energy is None:
-                obj.energy = 100
-            if obj.created_at is None:
-                obj.created_at = now
-            self.users_by_id[obj.id] = obj
-            self.users_by_email[obj.email] = obj
-            return
-
-        if isinstance(obj, UserSession):
-            if obj.created_at is None:
-                obj.created_at = now
-            self.sessions_by_id[obj.session_id] = obj
-            return
-
-        raise TypeError(f"Unsupported object type: {type(obj)!r}")
-
-    async def commit(self):
-        return None
-
-    async def refresh(self, _obj):
-        return None
-
-    async def execute(self, statement):
-        if statement.__class__.__name__ == "Select":
-            entity = statement.column_descriptions[0]["entity"]
-            where = statement.whereclause
-            if entity is User:
-                key = where.left.key
-                value = where.right.value
-                if key == "email":
-                    return FakeResult(scalar=self.users_by_email.get(value))
-                if key == "id":
-                    return FakeResult(scalar=self.users_by_id.get(value))
-
-            if entity is UserSession:
-                key = where.left.key
-                value = where.right.value
-                if key == "session_id":
-                    return FakeResult(scalar=self.sessions_by_id.get(value))
-
-        if statement.__class__.__name__ == "Delete" and statement.table.name == "sessions":
-            where = statement.whereclause
-            key = where.left.key
-            deleted_ids: list[tuple[str]] = []
-
-            if key == "session_id":
-                value = where.right.value
-                if value in self.sessions_by_id:
-                    del self.sessions_by_id[value]
-                    deleted_ids.append((value,))
-
-            if key == "expires_at":
-                deadline = where.right.value
-                expired_ids = [
-                    session_id
-                    for session_id, session in self.sessions_by_id.items()
-                    if session.expires_at <= deadline
-                ]
-                for session_id in expired_ids:
-                    del self.sessions_by_id[session_id]
-                    deleted_ids.append((session_id,))
-
-            return FakeResult(rows=deleted_ids)
-
-        raise AssertionError(f"Unsupported statement: {statement!r}")
-
-
-@contextmanager
-def auth_client():
-    db = FakeAsyncSession()
-
-    async def override_get_db():
-        yield db
-
-    app.dependency_overrides[get_db] = override_get_db
-    try:
-        with TestClient(app) as client:
-            yield client, db
-    finally:
-        app.dependency_overrides.clear()
+from tests.fakes import FakeAsyncSession, app_client as auth_client
 
 
 def test_register_sets_session_and_csrf_cookies():
-    with auth_client() as (client, db):
-        response = client.post(
-            "/auth/register",
-            json={
-                "email": "test@example.com",
-                "password": "password123",
-                "name": "tester",
-            },
-        )
+    async def run():
+        async with auth_client() as (client, db):
+            response = await client.post(
+                "/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "password123",
+                    "name": "tester",
+                },
+            )
 
-        assert response.status_code == 201
-        assert response.json()["message"] == "Registered successfully"
-        assert response.cookies.get("access_token")
-        assert response.cookies.get("csrf_token")
-        assert len(db.sessions_by_id) == 1
+            assert response.status_code == 201
+            assert response.json()["message"] == "Registered successfully"
+            assert response.cookies.get("access_token")
+            assert response.cookies.get("csrf_token")
+            assert len(db.sessions_by_id) == 1
+
+    asyncio.run(run())
 
 
 def test_me_works_with_session_cookie():
-    with auth_client() as (client, _db):
-        client.post(
-            "/auth/register",
-            json={
-                "email": "test@example.com",
-                "password": "password123",
-                "name": "tester",
-            },
-        )
+    async def run():
+        async with auth_client() as (client, _db):
+            await client.post(
+                "/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "password123",
+                    "name": "tester",
+                },
+            )
 
-        response = client.get("/auth/me")
+            response = await client.get("/auth/me")
 
-        assert response.status_code == 200
-        assert response.json()["email"] == "test@example.com"
+            assert response.status_code == 200
+            assert response.json()["email"] == "test@example.com"
+
+    asyncio.run(run())
 
 
 def test_login_rejects_invalid_password():
-    with auth_client() as (client, _db):
-        client.post(
-            "/auth/register",
-            json={
-                "email": "test@example.com",
-                "password": "password123",
-                "name": "tester",
-            },
-        )
-        client.cookies.clear()
+    async def run():
+        async with auth_client() as (client, _db):
+            await client.post(
+                "/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "password123",
+                    "name": "tester",
+                },
+            )
+            client.cookies.clear()
 
-        response = client.post(
-            "/auth/login",
-            json={
-                "email": "test@example.com",
-                "password": "wrongpass123",
-            },
-        )
+            response = await client.post(
+                "/auth/login",
+                json={
+                    "email": "test@example.com",
+                    "password": "wrongpass123",
+                },
+            )
 
-        assert response.status_code == 401
-        assert response.json()["detail"] == "Invalid email or password"
+            assert response.status_code == 401
+            assert response.json()["detail"] == "Invalid email or password"
+
+    asyncio.run(run())
 
 
 def test_logout_requires_csrf_header():
-    with auth_client() as (client, _db):
-        client.post(
-            "/auth/register",
-            json={
-                "email": "test@example.com",
-                "password": "password123",
-                "name": "tester",
-            },
-        )
+    async def run():
+        async with auth_client() as (client, _db):
+            await client.post(
+                "/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "password123",
+                    "name": "tester",
+                },
+            )
 
-        response = client.post("/auth/logout")
+            response = await client.post("/auth/logout")
 
-        assert response.status_code == 403
-        assert response.json()["detail"] == "CSRF token is required"
+            assert response.status_code == 403
+            assert response.json()["detail"] == "CSRF token is required"
+
+    asyncio.run(run())
 
 
 def test_logout_deletes_session_and_cookies():
-    with auth_client() as (client, db):
-        client.post(
-            "/auth/register",
-            json={
-                "email": "test@example.com",
-                "password": "password123",
-                "name": "tester",
-            },
-        )
-        csrf_token = client.cookies.get("csrf_token")
-        session_id = client.cookies.get("access_token")
+    async def run():
+        async with auth_client() as (client, db):
+            await client.post(
+                "/auth/register",
+                json={
+                    "email": "test@example.com",
+                    "password": "password123",
+                    "name": "tester",
+                },
+            )
+            csrf_token = client.cookies.get("csrf_token")
+            session_id = client.cookies.get("access_token")
 
-        response = client.post(
-            "/auth/logout",
-            headers={"X-CSRF-Token": csrf_token},
-        )
+            response = await client.post(
+                "/auth/logout",
+                headers={"X-CSRF-Token": csrf_token},
+            )
 
-        assert response.status_code == 200
-        assert session_id not in db.sessions_by_id
-        assert client.get("/auth/me").status_code == 401
+            assert response.status_code == 200
+            assert session_id not in db.sessions_by_id
+            assert (await client.get("/auth/me")).status_code == 401
+
+    asyncio.run(run())
 
 
 def test_delete_expired_sessions_removes_only_expired_rows():

--- a/back/tests/test_game.py
+++ b/back/tests/test_game.py
@@ -1,0 +1,167 @@
+import asyncio
+
+from tests.fakes import app_client
+
+
+def test_base_setup_creates_base_and_updates_user_home():
+    async def run():
+        async with app_client() as (client, db):
+            headers = await client.post(
+                "/auth/register",
+                json={
+                    "email": "game@example.com",
+                    "password": "password123",
+                    "name": "gamer",
+                },
+            )
+            assert headers.status_code == 201
+            csrf_headers = {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+            response = await client.post(
+                "/game/base",
+                json={
+                    "lat": 35.681236,
+                    "lng": 139.767125,
+                    "name": "Tokyo Base",
+                },
+                headers=csrf_headers,
+            )
+
+            assert response.status_code == 200
+            assert response.json()["name"] == "Tokyo Base"
+            assert len(db.bases_by_id) == 1
+            user = next(iter(db.users_by_id.values()))
+            assert user.home_lat == 35.681236
+            assert user.home_lng == 139.767125
+
+    asyncio.run(run())
+
+
+def test_base_setup_updates_existing_base():
+    async def run():
+        async with app_client() as (client, db):
+            response = await client.post(
+                "/auth/register",
+                json={
+                    "email": "game@example.com",
+                    "password": "password123",
+                    "name": "gamer",
+                },
+            )
+            assert response.status_code == 201
+            headers = {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+            first = await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+                headers=headers,
+            )
+            second = await client.post(
+                "/game/base",
+                json={"lat": 36.0, "lng": 140.0, "name": "Base B"},
+                headers=headers,
+            )
+
+            assert first.status_code == 200
+            assert second.status_code == 200
+            assert len(db.bases_by_id) == 1
+            base = next(iter(db.bases_by_id.values()))
+            assert base.name == "Base B"
+            assert base.lat == 36.0
+            assert base.lng == 140.0
+
+    asyncio.run(run())
+
+
+def test_game_start_requires_base():
+    async def run():
+        async with app_client() as (client, _db):
+            response = await client.post(
+                "/auth/register",
+                json={
+                    "email": "game@example.com",
+                    "password": "password123",
+                    "name": "gamer",
+                },
+            )
+            assert response.status_code == 201
+            headers = {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+            response = await client.post(
+                "/game/start",
+                json={"difficulty": 3},
+                headers=headers,
+            )
+
+            assert response.status_code == 400
+            assert response.json()["detail"] == "Base is not set"
+
+    asyncio.run(run())
+
+
+def test_game_start_creates_single_wave_and_initial_enemies():
+    async def run():
+        async with app_client() as (client, db):
+            response = await client.post(
+                "/auth/register",
+                json={
+                    "email": "game@example.com",
+                    "password": "password123",
+                    "name": "gamer",
+                },
+            )
+            assert response.status_code == 201
+            headers = {"X-CSRF-Token": client.cookies.get("csrf_token")}
+            await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+                headers=headers,
+            )
+
+            response = await client.post(
+                "/game/start",
+                json={"difficulty": 3},
+                headers=headers,
+            )
+
+            assert response.status_code == 201
+            body = response.json()
+            assert body["difficulty"] == 3
+            assert body["status"] == "active"
+            assert body["enemy_count"] == 9
+            assert "seed" not in body
+            assert len(db.waves_by_id) == 1
+            assert len(db.enemies_by_id) == 9
+            wave = next(iter(db.waves_by_id.values()))
+            assert wave.wave_type == "session"
+
+    asyncio.run(run())
+
+
+def test_game_start_rejects_when_active_wave_exists():
+    async def run():
+        async with app_client() as (client, db):
+            response = await client.post(
+                "/auth/register",
+                json={
+                    "email": "game@example.com",
+                    "password": "password123",
+                    "name": "gamer",
+                },
+            )
+            assert response.status_code == 201
+            headers = {"X-CSRF-Token": client.cookies.get("csrf_token")}
+            await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+                headers=headers,
+            )
+            first = await client.post("/game/start", json={"difficulty": 2}, headers=headers)
+            second = await client.post("/game/start", json={"difficulty": 4}, headers=headers)
+
+            assert first.status_code == 201
+            assert second.status_code == 409
+            assert second.json()["detail"] == "An active wave already exists"
+            assert len(db.waves_by_id) == 1
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
ゲーム開始前の拠点設定と、1セッション分のゲーム開始に必要な最小APIを実装しました。

## Changes
- `POST /game/base` を実装
- `POST /game/start` を実装
- game 用 Pydantic schema を追加
- `main.py` に game router を組み込み
- 1ユーザー1拠点として、既存拠点がある場合は更新する仕様に対応
- 拠点未設定時はゲーム開始できないように対応
- ゲーム開始時に `enemy_waves` を1件作成
- ゲーム開始時に初期 enemy を生成
- active wave の重複を防ぐ DB 制約を追加
- wave と enemy を同一保存フローで扱うように調整
- `seed` はレスポンスに返さないように変更
- fake DB テストを追加・整理
- PostgreSQL integration test を追加
- README に integration test 手順を追記

## Validation
- `pytest -q tests/test_auth.py tests/test_game.py`
  - `11 passed`
- `pytest -q tests/integration -m integration`
  - `5 passed`

## Notes
- 現時点では `1 session = 1 wave` の最小実装です
- DB には `back/db/init.sql` の反映が必要です
- active wave の一意性は PostgreSQL の部分ユニークインデックスで担保しています
- Supabase での最終疎通確認は、今後の API 実装と合わせて行う想定です
