### PR TITLE
close #11 防衛施設APIの小さめの実装

### DIFF
--- a/back/app/main.py
+++ b/back/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 from app.config import settings
 from app.db.engine import AsyncSessionLocal
-from app.routers import auth, game
+from app.routers import auth, game, structures
 from app.security import delete_expired_sessions
 
 
@@ -50,7 +50,7 @@ app.add_middleware(
 
 app.include_router(auth.router)
 app.include_router(game.router)
-# app.include_router(structures.router)
+app.include_router(structures.router)
 # app.include_router(enemies.router)
 
 

--- a/back/app/routers/structures.py
+++ b/back/app/routers/structures.py
@@ -1,3 +1,136 @@
-# POST   /structures/        現在地に防衛施設を配置（種類・緯度経度を受け取る）
-# GET    /structures/        配置済み施設の一覧取得
-# DELETE /structures/{id}    施設を撤去
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.engine import get_db
+from app.db.models import Base_ as UserBase
+from app.db.models import Structure, User
+from app.schemas.structure import PlaceStructureRequest, StructureResponse
+from app.security import get_current_user, validate_csrf
+
+router = APIRouter(prefix="/structures", tags=["structures"])
+
+STRUCTURE_DEFAULTS = {
+    "turret": {
+        "name": "Turret",
+        "hp": 120,
+        "max_hp": 120,
+        "attack": 18,
+        "range_m": 120,
+        "duration_sec": 86400,
+        "rarity": "common",
+        "metadata_json": {"effect": "damage"},
+    },
+    "wall": {
+        "name": "Wall",
+        "hp": 320,
+        "max_hp": 320,
+        "attack": 0,
+        "range_m": 20,
+        "duration_sec": 86400,
+        "rarity": "common",
+        "metadata_json": {"effect": "block"},
+    },
+    "slow": {
+        "name": "Slow Trap",
+        "hp": 90,
+        "max_hp": 90,
+        "attack": 4,
+        "range_m": 90,
+        "duration_sec": 86400,
+        "rarity": "common",
+        "metadata_json": {"effect": "slow"},
+    },
+}
+
+
+async def _get_user_base(db: AsyncSession, user_id: str) -> UserBase | None:
+    result = await db.execute(select(UserBase).where(UserBase.user_id == user_id))
+    return result.scalar_one_or_none()
+
+
+@router.post(
+    "/",
+    response_model=StructureResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def place_structure(
+    payload: PlaceStructureRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(validate_csrf),
+) -> StructureResponse:
+    base = await _get_user_base(db, current_user.id)
+    if base is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Base is not set",
+        )
+
+    defaults = STRUCTURE_DEFAULTS[payload.type]
+    structure = Structure(
+        user_id=current_user.id,
+        base_id=base.id,
+        type=payload.type,
+        lat=payload.lat,
+        lng=payload.lng,
+        **defaults,
+    )
+    db.add(structure)
+    await db.commit()
+    await db.refresh(structure)
+    return StructureResponse.model_validate(structure)
+
+
+@router.get("/", response_model=list[StructureResponse])
+async def list_structures(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[StructureResponse]:
+    result = await db.execute(select(Structure).where(Structure.user_id == current_user.id))
+    structures = sorted(
+        result.scalars().all(),
+        key=lambda structure: structure.placed_at,
+        reverse=True,
+    )
+    return [StructureResponse.model_validate(structure) for structure in structures]
+
+
+@router.delete("/{structure_id}")
+async def delete_structure(
+    structure_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _: None = Depends(validate_csrf),
+) -> dict[str, str]:
+    try:
+        normalized_structure_id = str(uuid.UUID(structure_id))
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Structure not found",
+        ) from None
+
+    result = await db.execute(
+        select(Structure).where(
+            Structure.id == normalized_structure_id,
+            Structure.user_id == current_user.id,
+        )
+    )
+    structure = result.scalar_one_or_none()
+    if structure is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Structure not found",
+        )
+
+    await db.execute(
+        delete(Structure).where(
+            Structure.id == normalized_structure_id,
+            Structure.user_id == current_user.id,
+        )
+    )
+    await db.commit()
+    return {"message": "Structure deleted successfully"}

--- a/back/app/schemas/structure.py
+++ b/back/app/schemas/structure.py
@@ -1,3 +1,30 @@
-# StructureType         turret（攻撃）/ wall（足止め）/ slow（減速）
-# PlaceStructureRequest type, lat, lng
-# StructureResponse     id, type, lat, lng, hp, max_hp, attack, range_m
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+StructureType = Literal["turret", "wall", "slow"]
+
+
+class PlaceStructureRequest(BaseModel):
+    type: StructureType
+    lat: float = Field(ge=-90, le=90)
+    lng: float = Field(ge=-180, le=180)
+
+
+class StructureResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    type: StructureType
+    name: str
+    lat: float
+    lng: float
+    hp: int
+    max_hp: int
+    attack: int
+    range_m: int
+    duration_sec: int
+    placed_at: datetime
+    rarity: str
+    metadata_json: dict

--- a/back/tests/fakes.py
+++ b/back/tests/fakes.py
@@ -7,8 +7,8 @@ from httpx import ASGITransport, AsyncClient
 
 from app.db.engine import get_db
 from app.db.models import Base_ as UserBase
-from app.db.models import Enemy, EnemyWave, User, UserSession
-from app.routers import auth, game
+from app.db.models import Enemy, EnemyWave, Structure, User, UserSession
+from app.routers import auth, game, structures
 
 
 class FakeScalarResult:
@@ -46,6 +46,7 @@ class FakeAsyncSession:
         self.sessions_by_id: dict[str, UserSession] = {}
         self.bases_by_id: dict[str, UserBase] = {}
         self.bases_by_user_id: dict[str, UserBase] = {}
+        self.structures_by_id: dict[str, Structure] = {}
         self.waves_by_id: dict[str, EnemyWave] = {}
         self.enemies_by_id: dict[str, Enemy] = {}
 
@@ -86,6 +87,16 @@ class FakeAsyncSession:
                 obj.created_at = now
             self.bases_by_id[obj.id] = obj
             self.bases_by_user_id[obj.user_id] = obj
+            return
+
+        if isinstance(obj, Structure):
+            if not obj.id:
+                obj.id = str(uuid.uuid4())
+            if obj.placed_at is None:
+                obj.placed_at = now
+            if obj.metadata_json is None:
+                obj.metadata_json = {}
+            self.structures_by_id[obj.id] = obj
             return
 
         if isinstance(obj, EnemyWave):
@@ -156,6 +167,18 @@ class FakeAsyncSession:
                 deleted_ids.append((session_id,))
             return FakeResult(rows=deleted_ids)
 
+        if statement_type == "Delete" and statement.table.name == "structures":
+            deleted_ids = []
+            to_delete = [
+                structure_id
+                for structure_id, structure in self.structures_by_id.items()
+                if self._matches(statement.whereclause, structure)
+            ]
+            for structure_id in to_delete:
+                del self.structures_by_id[structure_id]
+                deleted_ids.append((structure_id,))
+            return FakeResult(rows=deleted_ids)
+
         raise AssertionError(f"Unsupported statement: {statement!r}")
 
     def _iter_entity(self, entity):
@@ -165,6 +188,8 @@ class FakeAsyncSession:
             return self.sessions_by_id.values()
         if entity is UserBase:
             return self.bases_by_id.values()
+        if entity is Structure:
+            return self.structures_by_id.values()
         if entity is EnemyWave:
             return self.waves_by_id.values()
         if entity is Enemy:
@@ -206,6 +231,7 @@ async def app_client():
     test_app = FastAPI()
     test_app.include_router(auth.router)
     test_app.include_router(game.router)
+    test_app.include_router(structures.router)
 
     async def override_get_db():
         yield db

--- a/back/tests/integration/conftest.py
+++ b/back/tests/integration/conftest.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import NullPool
 
 from app.db.engine import get_db
-from app.routers import auth, game
+from app.routers import auth, game, structures
 
 TEST_DATABASE_URL = os.getenv(
     "TEST_DATABASE_URL",
@@ -84,6 +84,7 @@ async def integration_client(db_sessionmaker):
     test_app = FastAPI()
     test_app.include_router(auth.router)
     test_app.include_router(game.router)
+    test_app.include_router(structures.router)
 
     async def override_get_db():
         async with db_sessionmaker() as session:

--- a/back/tests/integration/test_structures_integration.py
+++ b/back/tests/integration/test_structures_integration.py
@@ -1,0 +1,132 @@
+import pytest
+from sqlalchemy import select
+
+from app.db.models import Structure
+
+
+async def _register(client, email="structures-integration@example.com"):
+    response = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": "password123",
+            "name": "integration-user",
+        },
+    )
+    assert response.status_code == 201
+    return {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+
+async def _setup_base(client, headers, lat=35.0, lng=139.0, name="Base A"):
+    response = await client.post(
+        "/game/base",
+        json={"lat": lat, "lng": lng, "name": name},
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.integration
+async def test_place_structure_requires_base(integration_client):
+    async with integration_client() as client:
+        headers = await _register(client)
+        response = await client.post(
+            "/structures/",
+            json={"type": "turret", "lat": 35.0, "lng": 139.0},
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Base is not set"
+
+
+@pytest.mark.integration
+async def test_place_and_list_structures(integration_client, db_sessionmaker):
+    async with integration_client() as client:
+        headers = await _register(client)
+        await _setup_base(client, headers)
+
+        first = await client.post(
+            "/structures/",
+            json={"type": "turret", "lat": 35.001, "lng": 139.001},
+            headers=headers,
+        )
+        second = await client.post(
+            "/structures/",
+            json={"type": "slow", "lat": 35.002, "lng": 139.002},
+            headers=headers,
+        )
+        listed = await client.get("/structures/")
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert listed.status_code == 200
+        assert len(listed.json()) == 2
+        assert {item["type"] for item in listed.json()} == {"turret", "slow"}
+
+    async with db_sessionmaker() as session:
+        structures = (await session.execute(select(Structure))).scalars().all()
+        assert len(structures) == 2
+
+
+@pytest.mark.integration
+async def test_invalid_structure_type_returns_422(integration_client):
+    async with integration_client() as client:
+        headers = await _register(client)
+        await _setup_base(client, headers)
+        response = await client.post(
+            "/structures/",
+            json={"type": "laser", "lat": 35.001, "lng": 139.001},
+            headers=headers,
+        )
+
+        assert response.status_code == 422
+
+
+@pytest.mark.integration
+async def test_delete_structure_only_allows_owner(integration_client, db_sessionmaker):
+    async with integration_client() as client:
+        owner_headers = await _register(client)
+        await _setup_base(client, owner_headers)
+        created = await client.post(
+            "/structures/",
+            json={"type": "wall", "lat": 35.003, "lng": 139.003},
+            headers=owner_headers,
+        )
+        structure_id = created.json()["id"]
+
+        other_headers = await _register(client, email="other-structures@example.com")
+        await _setup_base(client, other_headers, lat=36.0, lng=140.0, name="Other Base")
+        forbidden = await client.delete(
+            f"/structures/{structure_id}",
+            headers=other_headers,
+        )
+
+        assert forbidden.status_code == 404
+
+    async with db_sessionmaker() as session:
+        structures = (await session.execute(select(Structure))).scalars().all()
+        assert len(structures) == 1
+
+
+@pytest.mark.integration
+async def test_delete_structure_removes_owned_structure(integration_client, db_sessionmaker):
+    async with integration_client() as client:
+        headers = await _register(client)
+        await _setup_base(client, headers)
+        created = await client.post(
+            "/structures/",
+            json={"type": "wall", "lat": 35.003, "lng": 139.003},
+            headers=headers,
+        )
+        structure_id = created.json()["id"]
+
+        deleted = await client.delete(f"/structures/{structure_id}", headers=headers)
+        missing = await client.delete("/structures/missing-id", headers=headers)
+
+        assert deleted.status_code == 200
+        assert missing.status_code == 404
+
+    async with db_sessionmaker() as session:
+        structures = (await session.execute(select(Structure))).scalars().all()
+        assert len(structures) == 0

--- a/back/tests/test_structures.py
+++ b/back/tests/test_structures.py
@@ -1,0 +1,157 @@
+import asyncio
+
+from tests.fakes import app_client
+
+
+async def _register_and_get_headers(client, email="structure@example.com"):
+    response = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": "password123",
+            "name": "builder",
+        },
+    )
+    assert response.status_code == 201
+    return {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+
+def test_place_structure_requires_base():
+    async def run():
+        async with app_client() as (client, _db):
+            headers = await _register_and_get_headers(client)
+            response = await client.post(
+                "/structures/",
+                json={"type": "turret", "lat": 35.0, "lng": 139.0},
+                headers=headers,
+            )
+
+            assert response.status_code == 400
+            assert response.json()["detail"] == "Base is not set"
+
+    asyncio.run(run())
+
+
+def test_place_and_list_structures_for_current_user():
+    async def run():
+        async with app_client() as (client, db):
+            headers = await _register_and_get_headers(client)
+            await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+                headers=headers,
+            )
+
+            first = await client.post(
+                "/structures/",
+                json={"type": "turret", "lat": 35.001, "lng": 139.001},
+                headers=headers,
+            )
+            second = await client.post(
+                "/structures/",
+                json={"type": "slow", "lat": 35.002, "lng": 139.002},
+                headers=headers,
+            )
+            listed = await client.get("/structures/")
+
+            assert first.status_code == 201
+            assert second.status_code == 201
+            assert listed.status_code == 200
+            body = listed.json()
+            assert len(body) == 2
+            assert {item["type"] for item in body} == {"turret", "slow"}
+            assert len(db.structures_by_id) == 2
+            assert body[0]["placed_at"] >= body[1]["placed_at"]
+
+    asyncio.run(run())
+
+
+def test_place_structure_rejects_invalid_type():
+    async def run():
+        async with app_client() as (client, _db):
+            headers = await _register_and_get_headers(client)
+            await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+                headers=headers,
+            )
+            response = await client.post(
+                "/structures/",
+                json={"type": "laser", "lat": 35.001, "lng": 139.001},
+                headers=headers,
+            )
+
+            assert response.status_code == 422
+
+    asyncio.run(run())
+
+
+def test_delete_structure_only_allows_owner():
+    async def run():
+        async with app_client() as (client, db):
+            owner_headers = await _register_and_get_headers(client)
+            await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Owner Base"},
+                headers=owner_headers,
+            )
+            created = await client.post(
+                "/structures/",
+                json={"type": "wall", "lat": 35.003, "lng": 139.003},
+                headers=owner_headers,
+            )
+            structure_id = created.json()["id"]
+
+            other = await client.post(
+                "/auth/register",
+                json={
+                    "email": "other@example.com",
+                    "password": "password123",
+                    "name": "other",
+                },
+            )
+            assert other.status_code == 201
+            other_headers = {"X-CSRF-Token": client.cookies.get("csrf_token")}
+            await client.post(
+                "/game/base",
+                json={"lat": 36.0, "lng": 140.0, "name": "Other Base"},
+                headers=other_headers,
+            )
+
+            forbidden = await client.delete(
+                f"/structures/{structure_id}",
+                headers=other_headers,
+            )
+
+            assert forbidden.status_code == 404
+            assert len(db.structures_by_id) == 1
+
+    asyncio.run(run())
+
+
+def test_delete_structure_removes_owned_structure_and_404s_for_missing():
+    async def run():
+        async with app_client() as (client, db):
+            headers = await _register_and_get_headers(client)
+            await client.post(
+                "/game/base",
+                json={"lat": 35.0, "lng": 139.0, "name": "Base A"},
+                headers=headers,
+            )
+            created = await client.post(
+                "/structures/",
+                json={"type": "wall", "lat": 35.003, "lng": 139.003},
+                headers=headers,
+            )
+            structure_id = created.json()["id"]
+
+            deleted = await client.delete(f"/structures/{structure_id}", headers=headers)
+            missing = await client.delete("/structures/missing-id", headers=headers)
+
+            assert deleted.status_code == 200
+            assert deleted.json()["message"] == "Structure deleted successfully"
+            assert missing.status_code == 404
+            assert missing.json()["detail"] == "Structure not found"
+            assert len(db.structures_by_id) == 0
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
防衛施設の配置・取得・撤去を行う最小APIを実装しました。地図画面から施設を置いて一覧取得し、不要になった施設を撤去できる状態です。

## Changes
- `POST /structures/` を実装
- `GET /structures/` を実装
- `DELETE /structures/{id}` を実装
- structure 用 Pydantic schema を追加
- `main.py` に structures router を組み込み
- `turret / wall / slow` の初期パラメータを追加
- 施設を user / base に紐付けて保存するように対応
- 拠点未設定時は施設を配置できないように対応
- 自分の施設だけ撤去できるように対応
- 存在しない ID や不正な type に対して適切な 4xx を返すように対応
- fake test / integration test を追加

## Validation
- `./.venv/bin/pytest -q tests/test_auth.py tests/test_game.py tests/test_structures.py`
  - `16 passed`
- `./.venv/bin/pytest -q tests/integration/test_structures_integration.py -m integration`
  - `5 passed`

## Notes
- 厳密な距離制限や重なり判定は今回の対象外
- 将来的な拡張を見越して `metadata_json` を返却に含めています
